### PR TITLE
Fix initialization options location

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It has three layers: `base`, `fragment1` and `fragment2`.
       <script>
         ...
         Reveal.initialize({
+          ...
           dependencies: [
             ...
             {
@@ -43,15 +44,17 @@ It has three layers: `base`, `fragment1` and `fragment2`.
               condition: function(){
                 return !!document.querySelector( '[data-svg-fragment]' );
               }
-              // Additional options
-              // defaults to using already-loaded version, or CDN
-              //d3: "./d3.min.js",
-              // use a different attribute for your fragment selector
-              //selector: "title",
             }
             ...
           ]
         ...
+        // Additional options
+        //svgFragment: {
+          // defaults to using already-loaded version, or CDN
+          //d3: "./d3.min.js",
+          // use a different attribute for your fragment selector
+          //selector: "title",
+        //}
         }
         ...
       </script>


### PR DESCRIPTION
I found out that the current version of reveal.js requires that the options (like 'd3' for the local d3.js location, for instance) be provided as a `svgFragment` parameter passed to initialize.