### PR TITLE
Update for Reveal 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,9 @@ It has three layers: `base`, `fragment1` and `fragment2`.
     - `python -m SimpleHTTPServer`
 - probably won't work in IE
   - wontfix
+
+## org-reveal example
+
+See `org-reveal-example.org` for an example using org-mode and
+[org-reveal](https://github.com/yjwen/org-reveal), converted from the
+provided example.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It has three layers: `base`, `fragment1` and `fragment2`.
       <script>
         ...
         Reveal.initialize({
+          ...
           dependencies: [
             ...
             {
@@ -43,15 +44,17 @@ It has three layers: `base`, `fragment1` and `fragment2`.
               condition: function(){
                 return !!document.querySelector( '[data-svg-fragment]' );
               }
-              // Additional options
-              // defaults to using already-loaded version, or CDN
-              //d3: "./d3.min.js",
-              // use a different attribute for your fragment selector
-              //selector: "title",
             }
             ...
           ]
         ...
+        // Additional options
+        //svgFragment: {
+          // defaults to using already-loaded version, or CDN
+          //d3: "./d3.min.js",
+          // use a different attribute for your fragment selector
+          //selector: "title",
+        //}
         }
         ...
       </script>

--- a/example/index.html
+++ b/example/index.html
@@ -14,29 +14,30 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/reveal.js@3.6.0/css/reveal.min.css">
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/reveal.js@3.6.0/css/theme/white.css" id="theme">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/reset.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/reveal.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/theme/white.css" id="theme">
 
     <!-- For syntax highlighting -->
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/reveal.js@3.6.0/lib/css/zenburn.css">
-
+    <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/lib/css/zenburn.css">
+    -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/plugin/highlight/monokai.css">
+    
     <!-- If the query includes 'print-pdf', include the PDF print sheet -->
-    <script>
-      if( window.location.search.match( /print-pdf/gi ) ) {
-        var link = document.createElement( 'link' );
-        link.rel = 'stylesheet';
-        link.type = 'text/css';
-        link.href = '//cdn.jsdelivr.net/npm/reveal.js@3.6.0/css/print/pdf.css';
-        document.getElementsByTagName( 'head' )[0].appendChild( link );
-      }
-    </script>
+    <!-- <script>
+         if( window.location.search.match( /print-pdf/gi ) ) {
+         var link = document.createElement( 'link' );
+         link.rel = 'stylesheet';
+         link.type = 'text/css';
+         link.href = 'https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/css/print/pdf.css';
+         document.getElementsByTagName( 'head' )[0].appendChild( link );
+         }
+         </script>
+    -->
     <style>
       .column{ width: 50%; float:left;}
     </style>
 
-    <!--[if lt IE 9]>
-    <script src="lib/js/html5shiv.js"></script>
-    <![endif]-->
   </head>
 
   <body>
@@ -93,11 +94,14 @@
 
     </div>
 
-    <script src="//cdn.jsdelivr.net/npm/reveal.js@3.6.0/lib/js/head.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/reveal.js@3.6.0/js/reveal.min.js"></script>
-
+    <!-- <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/lib/js/head.min.js"></script> -->
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/reveal.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/plugin/notes/notes.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/plugin/markdown/markdown.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/plugin/highlight/highlight.js"></script>
+                
     <script>
-      var cdn = "//cdn.jsdelivr.net/npm/reveal.js@3.6.0/";
+      var cdn = "//cdn.jsdelivr.net/npm/reveal.js@4.5.0/";
       // Full list of configuration options available here:
       // https://github.com/hakimel/reveal.js#configuration
       Reveal.initialize({
@@ -106,21 +110,22 @@
         history: true,
         center: true,
 
-        theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
-        transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none
-
+        /* theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
+         * transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/zoom/linear/fade/none
+         */
         // Parallax scrolling
         // parallaxBackgroundImage: 'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg',
         // parallaxBackgroundSize: '2100px 900px',
-
+        plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ],
+        
         // Optional libraries used to extend on reveal.js
         dependencies: [
-          { src: cdn + 'lib/js/classList.js', condition: function() { return !document.body.classList; } },
-          { src: cdn + 'plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-          { src: cdn + 'plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-          { src: cdn + 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-          { src: cdn + 'plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-          { src: cdn + 'plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
+          /* { src: cdn + 'lib/js/classList.js', condition: function() { return !document.body.classList; } }, */
+          /* { src: cdn + 'plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } }, */
+          /* { src: cdn + 'plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } }, */
+          /* { src: cdn + 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }, */
+          /* { src: cdn + 'plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } }, */
+          /* { src: cdn + 'plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }, */
           { src: '../reveal-svg-fragment.js', condition: function() { return !!document.querySelector( '[data-svg-fragment]' ); } }
         ]
       });

--- a/org-reveal-example.org
+++ b/org-reveal-example.org
@@ -50,7 +50,8 @@ Works with [[http://inkscape.org][Inkscape]]
 #+ATTR_HTML: :style font-size: 60%;
 Created by [[http://github.com/bollwyvl][@bollwyvl]] for reveal.js
 
-Example adapted for [[https://github.com/yjwen/org-reveal][org-reveal]]
+Example adapted for
+[[https://github.com/yjwen/org-reveal][org-reveal]] by =@olberger= here: https://github.com/olberger/reveal-svg-fragment
 
 * Basic HTML Test
 
@@ -69,6 +70,12 @@ Example adapted for [[https://github.com/yjwen/org-reveal][org-reveal]]
               <a class="fragment" title="[*|label=fragment2]"></a>
             </div>
 #+END_EXPORT
+
+* Questions / Feedback
+
+Comment/fork on [[https://github.com/csachs/reveal-svg-fragment][GitHub]] (original) or [[https://github.com/olberger/reveal-svg-fragment][olberger's fork]]
+
+file:example/github.svg
 
 # Local Variables:
 # End:

--- a/org-reveal-example.org
+++ b/org-reveal-example.org
@@ -20,12 +20,14 @@
 #+REVEAL_HLEVEL: 1
 #+REVEAL_THEME: white
 #+REVEAL_ROOT: https://cdn.jsdelivr.net/npm/reveal.js
-#+REVEAL_EXTRA_JS:      { src: './reveal-svg-fragment.js' }
+#+REVEAL_EXTRA_JS:      { src: './reveal-svg-fragment.js', condition: function() { return !!document.querySelector( '[data-svg-fragment]' ); } }
 
 #+OPTIONS: tags:nil ^:nil
 
 #+OPTIONS: reveal_title_slide:nil
 
+# Change the d3 location here if needed, with the svgFragment option
+# +REVEAL_INIT_OPTIONS: controls: true, progress: true, history: true, center: true, svgFragment: { d3: "./js/d3.min.js" }
 #+REVEAL_INIT_OPTIONS: controls: true, progress: true, history: true, center: true
 
 * Reveal.js SVG Fragments

--- a/org-reveal-example.org
+++ b/org-reveal-example.org
@@ -1,0 +1,72 @@
+#+Title: Reveal.js SVG Fragments with Org-Reveal
+#+Author: Olivier Berger
+#+Email: olivier.berger@telecom-sudparis.eu
+
+#+OPTIONS: num:nil 
+#+OPTIONS: toc:nil
+#+OPTIONS: num:nil tags:t
+
+#+KEYWORDS:
+#+LANGUAGE:  en
+#+OPTIONS:   TeX:t LaTeX:t skip:nil d:nil todo:t pri:nil tags:not-in-toc ':t
+#+EXPORT_SELECT_TAGS: export
+#+EXPORT_EXCLUDE_TAGS: noexport
+#+LINK_UP:   
+#+LINK_HOME: 
+#+XSLT:
+
+#+OPTIONS: html-preamble:nil html-scripts:nil html-style:nil
+
+#+REVEAL_HLEVEL: 1
+#+REVEAL_THEME: white
+#+REVEAL_ROOT: https://cdn.jsdelivr.net/npm/reveal.js
+#+REVEAL_EXTRA_JS:      { src: './reveal-svg-fragment.js' }
+
+#+OPTIONS: tags:nil ^:nil
+
+#+OPTIONS: reveal_title_slide:nil
+
+#+REVEAL_INIT_OPTIONS: controls: true, progress: true, history: true, center: true
+
+* Reveal.js SVG Fragments
+
+#+REVEAL_HTML: <div class="column" style="float: left; width: 50%">
+Built with [[http://d3js.org][d3]]
+
+[[file:example/d3.svg]]
+#+REVEAL_HTML: </div>
+
+#+REVEAL_HTML: <div class="column" style="float: right; width: 50%">
+Works with [[http://inkscape.org][Inkscape]]
+
+[[file:example/inkscape.svg]]
+#+REVEAL_HTML: </div>
+
+# NBSP here:
+ 
+
+#+ATTR_HTML: :style font-size: 60%;
+Created by [[http://github.com/bollwyvl][@bollwyvl]] for reveal.js
+
+Example adapted for [[https://github.com/yjwen/org-reveal][org-reveal]]
+
+* Basic HTML Test
+
+#+BEGIN_EXPORT html
+<div data-svg-fragment="example/test.svg#[*|label=base]">
+            <a class="fragment" title="[*|label=fragment1]"></a>
+            <a class="fragment" title="[*|label=fragment2]"></a>
+          </div>
+#+END_EXPORT
+ 
+* Another order
+
+#+BEGIN_EXPORT html
+<div data-svg-fragment="example/test.svg#[*|label=fragment1]">
+              <a class="fragment" title="[*|label=base]"></a>
+              <a class="fragment" title="[*|label=fragment2]"></a>
+            </div>
+#+END_EXPORT
+
+# Local Variables:
+# End:


### PR DESCRIPTION
I guess the plugin's code should be updated, but in the meantime, it seems to still be compatible to Reveal 4.5.

Hence the suggestion to update the example HTML file for reveal 4.5... 

Not sure at all if everything is solid that way.